### PR TITLE
Added --wsn-compatible mode.

### DIFF
--- a/ble-adv-scanner/README.md
+++ b/ble-adv-scanner/README.md
@@ -5,10 +5,12 @@ Author: Ondřej Hujňák <hujnak@cesnet.cz>
 
 Goal: Provide BLE devices which are in proximity of the BLE controller.
 
-Inputs:  --
-Outputs: UniRec [macaddr BDADDR, time TIME, int8 RSSI, uint8 ATYPE]
+	Inputs:  --
+	Outputs: 1 output with two possible definitions
+		* UniRec [macaddr BDADDR, time TIME, int8 RSSI, uint8 ATYPE]
+		* UniRec [uint64 ID, time TIME, int8 RSSI, uint8 ATYPE]
 
-Usage: python3 ble_adv_scanner.py -i IFC_SPEC
+Usage: python3 ble_adv_scanner.py [--wsn-compatible] -i IFC_SPEC
 
 Example: python3 ble_adv_scanner.py -i "u:socket"
 
@@ -19,7 +21,11 @@ controller, which communicates via HCI. Scanning itself is by default passive,
 so no packets are sent out and all reported devices are discovered by cyclic
 listening to advertising channels.
 
+If ran with --wsn-compatible argument, use _uint64 ID_ instead of BDADDR for
+compatibility with WSN_Anomaly_Detector.
+
 ## UniRec output format
+	uint64	ID	- Bluetooth address in the form of 48bit uint number
 	macaddr BDADDR	- Bluetooth address of the discovered device
 	time	TIME	- Timestamp of the device discovery
 	int8	RSSI	- Signal strength (distance) of the device


### PR DESCRIPTION
In order to work with WSN_Anomaly_Detector, BDADDR is sent in the form of
uint64 with label ID.

Signed-off-by: Ondřej Hujňák <hujnak@cesnet.cz>